### PR TITLE
Add stopPropagation wrapper on Avatar click event

### DIFF
--- a/components/Avatar/Avatar.tsx
+++ b/components/Avatar/Avatar.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import ImageAvatar from "./ImageAvatar";
 import NameAvatar from "./NameAvatar";
 
@@ -11,16 +12,31 @@ interface AvatarProps {
 export default function Avatar(props: AvatarProps) {
   const { className, avatarUrl, name, onClick } = props;
 
+  const onClickNoPropogate = useCallback(
+    (e?) => {
+      if (e) {
+        e.stopPropagation();
+      }
+      if (onClick) {
+        onClick();
+      }
+    },
+    [onClick]
+  );
   return (
     <>
       {avatarUrl ? (
         <ImageAvatar
           className={className}
           avatarUrl={avatarUrl}
-          onClick={onClick}
+          onClick={onClickNoPropogate}
         />
       ) : (
-        <NameAvatar className={className} name={name} onClick={onClick} />
+        <NameAvatar
+          className={className}
+          name={name}
+          onClick={onClickNoPropogate}
+        />
       )}
     </>
   );

--- a/components/Buttons/index.tsx
+++ b/components/Buttons/index.tsx
@@ -5,7 +5,7 @@ interface RoundedButtonProps {
   text: string;
   icon?: React.ReactNode;
   className?: string;
-  onClick?: () => void;
+  onClick?: (e?: React.MouseEvent<HTMLElement>) => void;
 }
 
 export function RedRoundedButton(props: RoundedButtonProps) {


### PR DESCRIPTION
Fixes issue where clicking on avatar which appeared in a parent element leads to both onClick events being called, sometimes leading to user being redirected to wrong page.